### PR TITLE
Eager realization

### DIFF
--- a/src/TIFF.jl
+++ b/src/TIFF.jl
@@ -6,6 +6,7 @@ using FixedPointNumbers
 using IndirectArrays
 using OffsetArrays
 using ProgressMeter
+using Base.Iterators
 
 include("enum.jl")
 include("utils.jl")

--- a/src/types/dense.jl
+++ b/src/types/dense.jl
@@ -15,7 +15,7 @@ struct DenseTaggedImage{T, N, O <: Unsigned,AA <: AbstractArray} <: AbstractDens
 end
 
 function DenseTaggedImage(data::AbstractArray{T, 2}, ifd::IFD{O}) where {T, O}
-    DenseTaggedImage{T, 2}(data, IFD{O}[ifd])
+    DenseTaggedImage(data, IFD{O}[ifd])
 end
 
 Base.size(t::DenseTaggedImage) = size(t.data)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ColorTypes
+using ColorVectorSpace
 using Documenter
 using FixedPointNumbers
+using Statistics
 using Test
 using TIFF
 
@@ -25,6 +27,18 @@ end
     img = TIFF.load(filepath)
     @test size(img) == (128, 128, 27)
     @test eltype(img) == RGB{N0f16}
+
+    @testset "Multiple planes" begin
+        # test slice based access
+        @test Gray(mean(img[:, :, 2])) == Gray{Float32}(0.25676906f0)
+
+        # make sure IFDs are included if whole slice is grabbed
+        @test length(img[:, :, 2].ifds) == 1
+        @test length(img[:, :, 2:5].ifds) == 4
+
+        # make sure that subslicing in XY drops IFD info
+        @test typeof(img[:, 50:60, 27]) == Array{RGB{Normed{UInt16,16}},2}
+    end
 end
 
 @testset "Floating point RGB image" begin


### PR DESCRIPTION
This fixes #4. Now, `TIFF.jl` will fully realize the lazily transformed images before returning them so access times are essentially the same as ImageMagick while preserving a lot of the speed/memory advantages:

## Load benchmarking: This PR vs ImageMagick.jl v1.1.6

| load time (lower is better) | memory usage during load (lower is better) |
|---------|---------------|
| ![timing](https://user-images.githubusercontent.com/1661487/103431543-6bba3b80-4b86-11eb-8f95-6aacde3c249f.png) |  ![memory](https://user-images.githubusercontent.com/1661487/103431542-6a890e80-4b86-11eb-975d-24b6ba6bcd3f.png) |

It looks like `TIFF.jl` beats ImageMagick both in load time and memory usage on every test except involving Packbits compression (`capitol.tif`) and `bali.tif` where `TIFF.jl` fails because of #8.

## Access times

But now access times are much improved:

```julia
julia> using TIFF, ImageMagick, BenchmarkTools

julia> img = TIFF.load("house.tif");

julia> @btime img[1,1];
  17.500 ns (1 allocation: 16 bytes)

julia> img = ImageMagick.load("house.tif");

julia> @btime img[1,1];
  16.990 ns (1 allocation: 16 bytes)
```

## Limitations

There are still some limitations with images with many planes since I lazily transform each plane and then realize them each round. These lazy transforms currently rely on if/else statements, which is not great. I need to explore offloading this work to compile time and dispatch on the TIFF structure.