### PR TITLE
Reverse byte order when reading remote data types

### DIFF
--- a/src/tags.jl
+++ b/src/tags.jl
@@ -16,8 +16,13 @@ function load(tf::TiffFile{O}, t::Tag{O}) where {O}
     pos = position(tf.io)
     seek(tf, loc)
     read!(tf, data)
-    if tf.need_bswap
+
+    # if this datatype is comprised of multiple bytes and this file needs to be
+    # bitswapped then we'll need to reverse the byte order inside each datatype
+    # unit 
+    if tf.need_bswap && bytes(t.datatype) >= 2
         reverse!(data)
+        data .= Array(reinterpret(UInt8, Array{t.datatype}(reverse(reinterpret(t.datatype, data)))))
     end
     seek(tf, pos)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,6 @@ get_example(name) = download("https://github.com/tlnagy/exampletiffs/blob/master
     @test img[50,50] == Gray{N0f8}(0.804) # value from ImageMagick.jl
     img[50:300, 50:150] .= 0.0
     @test img[50, 50] == Gray{N0f8}(0.0)
-0
 end
 
 @testset "MRI stack" begin
@@ -69,4 +68,24 @@ end
     @test size(img) == (167, 439, 35)
     expected_rng = reinterpret.(Q0f7, Int8.((-1, 96)))
     @test extrema(img[:, :, 1]) == expected_rng
+end
+
+@testset "Issue #12" begin
+    @testset "Big endian striped file" begin
+        filepath = get_example("flagler.tif")
+        img = TIFF.load(filepath)
+
+        # verify that strip offsets are correctly bswapped for endianness
+        img_stripoffsets = Int.(img.ifds[1][TIFF.STRIPOFFSETS].data)
+        @test img_stripoffsets == [8, 129848, 259688, 389528]
+    end
+
+    @testset "Little endian striped file" begin
+        filepath = get_example("house.tif")
+        img = TIFF.load(filepath)
+
+        # verify that strip offsets are correctly bswapped for endianness
+        img_stripoffsets = Int.(img.ifds[1][TIFF.STRIPOFFSETS].data)
+        @test issorted(img_stripoffsets)
+    end
 end


### PR DESCRIPTION
I was naively reversing the byte order when loading remote tag data
without grouping the bytes to which value they will be reinterpreted
as. Fixes #12